### PR TITLE
feat: Add TikTok embed fixer support

### DIFF
--- a/fixer.test.ts
+++ b/fixer.test.ts
@@ -57,3 +57,45 @@ test("handle broken spoilers", () => {
   const fixed = fixMsg(content);
   expect(fixed).toEqual([FIXED_URL]);
 });
+
+// TikTok tests
+const TIKTOK_TEST_URL = "https://www.tiktok.com/@username/video/1234567890";
+const TIKTOK_FIXED_URL = "https://www.tnktok.com/@username/video/1234567890";
+const TIKTOK_FIXED_SPOILER = `||${TIKTOK_FIXED_URL}||`;
+
+const TIKTOK_SHORT_URL = "https://vm.tiktok.com/ZMjKL1234/";
+const TIKTOK_SHORT_FIXED = "https://vm.tnktok.com/ZMjKL1234/";
+
+test("fix tiktok url", () => {
+  const fixed = fixMsg(TIKTOK_TEST_URL);
+  expect(fixed).toEqual([TIKTOK_FIXED_URL]);
+});
+
+test("fix tiktok short url", () => {
+  const fixed = fixMsg(TIKTOK_SHORT_URL);
+  expect(fixed).toEqual([TIKTOK_SHORT_FIXED]);
+});
+
+test("fix tiktok url in text", () => {
+  const content = `check this out ${TIKTOK_TEST_URL} amazing video`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([TIKTOK_FIXED_URL]);
+});
+
+test("fix multiple tiktok urls", () => {
+  const content = `${TIKTOK_TEST_URL} and ${TIKTOK_SHORT_URL}`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([TIKTOK_FIXED_URL, TIKTOK_SHORT_FIXED]);
+});
+
+test("handle tiktok spoilers", () => {
+  const content = `secret video ||${TIKTOK_TEST_URL}||`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([TIKTOK_FIXED_SPOILER]);
+});
+
+test("fix both twitter and tiktok urls", () => {
+  const content = `${TEST_URL} and ${TIKTOK_TEST_URL}`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([FIXED_URL, TIKTOK_FIXED_URL]);
+});


### PR DESCRIPTION
Add support for fixing TikTok URLs to use tnktok.com service for better Discord embeds.
Supports standard URLs (www.tiktok.com), short URLs (vm.tiktok.com, vt.tiktok.com),
and preserves spoiler tags. Also fixes SECRET_FIXERS bug where empty string would be
used as domain replacement.