### PR TITLE
Add Instagram embed support with dd prefix

### DIFF
--- a/fixer.test.ts
+++ b/fixer.test.ts
@@ -99,3 +99,45 @@ test("fix both twitter and tiktok urls", () => {
   const fixed = fixMsg(content);
   expect(fixed).toEqual([FIXED_URL, TIKTOK_FIXED_URL]);
 });
+
+// Instagram tests
+const INSTAGRAM_TEST_URL = "https://www.instagram.com/p/ABC123/";
+const INSTAGRAM_FIXED_URL = "https://www.ddinstagram.com/p/ABC123/";
+const INSTAGRAM_FIXED_SPOILER = `||${INSTAGRAM_FIXED_URL}||`;
+
+const INSTAGRAM_REEL_URL = "https://www.instagram.com/reel/XYZ789/";
+const INSTAGRAM_REEL_FIXED = "https://www.ddinstagram.com/reel/XYZ789/";
+
+test("fix instagram url", () => {
+  const fixed = fixMsg(INSTAGRAM_TEST_URL);
+  expect(fixed).toEqual([INSTAGRAM_FIXED_URL]);
+});
+
+test("fix instagram reel url", () => {
+  const fixed = fixMsg(INSTAGRAM_REEL_URL);
+  expect(fixed).toEqual([INSTAGRAM_REEL_FIXED]);
+});
+
+test("fix instagram url in text", () => {
+  const content = `check this out ${INSTAGRAM_TEST_URL} cool post`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([INSTAGRAM_FIXED_URL]);
+});
+
+test("fix multiple instagram urls", () => {
+  const content = `${INSTAGRAM_TEST_URL} and ${INSTAGRAM_REEL_URL}`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([INSTAGRAM_FIXED_URL, INSTAGRAM_REEL_FIXED]);
+});
+
+test("handle instagram spoilers", () => {
+  const content = `secret post ||${INSTAGRAM_TEST_URL}||`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([INSTAGRAM_FIXED_SPOILER]);
+});
+
+test("fix twitter, tiktok, and instagram urls", () => {
+  const content = `${TEST_URL} and ${TIKTOK_TEST_URL} and ${INSTAGRAM_TEST_URL}`;
+  const fixed = fixMsg(content);
+  expect(fixed).toEqual([FIXED_URL, TIKTOK_FIXED_URL, INSTAGRAM_FIXED_URL]);
+});

--- a/fixer.ts
+++ b/fixer.ts
@@ -2,8 +2,9 @@ export function fixMsg(content: string): string[] {
   const spoilers = getSpoilers(content);
   const twitterFixes = fixTwitterUrls(content, spoilers);
   const tiktokFixes = fixTikTokUrls(content, spoilers);
+  const instagramFixes = fixInstagramUrls(content, spoilers);
 
-  return [...twitterFixes, ...tiktokFixes];
+  return [...twitterFixes, ...tiktokFixes, ...instagramFixes];
 }
 
 const SPOILER = "||";
@@ -73,10 +74,31 @@ function fixTikTokUrls(content: string, spoilers: number[][]): string[] {
   return fixes;
 }
 
+function fixInstagramUrls(content: string, spoilers: number[][]): string[] {
+  const fixes: string[] = [];
+  const instagramMatches = Array.from(content.matchAll(/https:\/\/(?:www\.)?instagram\.com\/[^\s|]*/g));
+
+  for (const match of instagramMatches) {
+    const index = match.index;
+    if (index === undefined) continue;
+
+    let fix = match[0].replace(/instagram\.com/, getInstagramFixer());
+
+    for (const [start, end] of spoilers) {
+      if (index > start && index < end) fix = `||${fix}||`;
+    }
+
+    fixes.push(fix);
+  }
+
+  return fixes;
+}
+
 const DEFAULT_TWITTER_FIX = "fxtwitter.com";
 const SECRET_FIXERS = (process.env.SECRET_FIXERS || "").split(",").filter(s => s.length > 0);
 
 const DEFAULT_TIKTOK_FIX = "tnktok.com";
+const DEFAULT_INSTAGRAM_FIX = "ddinstagram.com";
 
 function getTwitterFixer(): string {
   if (SECRET_FIXERS.length === 0) return DEFAULT_TWITTER_FIX;
@@ -87,4 +109,8 @@ function getTwitterFixer(): string {
 
 function getTikTokFixer(): string {
   return DEFAULT_TIKTOK_FIX;
+}
+
+function getInstagramFixer(): string {
+  return DEFAULT_INSTAGRAM_FIX;
 }


### PR DESCRIPTION
- Implements fixInstagramUrls function following InstaFix pattern
- Adds "dd" before instagram.com URLs (instagram.com -> ddinstagram.com)
- Supports all Instagram URL formats including posts and reels
- Includes comprehensive test coverage for Instagram embeds
- Maintains spoiler tag support for Instagram URLs