### PR TITLE
Fix Instagram embed support with new provider

### DIFF
--- a/fixer.test.ts
+++ b/fixer.test.ts
@@ -102,11 +102,11 @@ test("fix both twitter and tiktok urls", () => {
 
 // Instagram tests
 const INSTAGRAM_TEST_URL = "https://www.instagram.com/p/ABC123/";
-const INSTAGRAM_FIXED_URL = "https://www.ddinstagram.com/p/ABC123/";
+const INSTAGRAM_FIXED_URL = "https://www.kkinstagram.com/p/ABC123/";
 const INSTAGRAM_FIXED_SPOILER = `||${INSTAGRAM_FIXED_URL}||`;
 
 const INSTAGRAM_REEL_URL = "https://www.instagram.com/reel/XYZ789/";
-const INSTAGRAM_REEL_FIXED = "https://www.ddinstagram.com/reel/XYZ789/";
+const INSTAGRAM_REEL_FIXED = "https://www.kkinstagram.com/reel/XYZ789/";
 
 test("fix instagram url", () => {
   const fixed = fixMsg(INSTAGRAM_TEST_URL);

--- a/fixer.ts
+++ b/fixer.ts
@@ -98,7 +98,7 @@ const DEFAULT_TWITTER_FIX = "fxtwitter.com";
 const SECRET_FIXERS = (process.env.SECRET_FIXERS || "").split(",").filter(s => s.length > 0);
 
 const DEFAULT_TIKTOK_FIX = "tnktok.com";
-const DEFAULT_INSTAGRAM_FIX = "ddinstagram.com";
+const DEFAULT_INSTAGRAM_FIX = "kkinstagram.com";
 
 function getTwitterFixer(): string {
   if (SECRET_FIXERS.length === 0) return DEFAULT_TWITTER_FIX;


### PR DESCRIPTION
….com

The previous Instagram fixer (ddinstagram.com) was not working properly. Updated to use kkinstagram.com as the new Instagram embed fixer service. Updated all related tests to reflect this change.